### PR TITLE
fix: remove persist-credentials from release-plz workflow

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -22,7 +22,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          persist-credentials: false
           # Use PAT to allow triggering other workflows (like release.yml)
           token: ${{ secrets.RELEASE_PLZ_TOKEN || secrets.GITHUB_TOKEN }}
 
@@ -54,7 +53,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          persist-credentials: false
           # Use PAT to allow triggering CI workflows on the release PR
           token: ${{ secrets.RELEASE_PLZ_TOKEN || secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Description

Remove `persist-credentials: false` from checkout actions in the release-plz workflow to allow proper authentication with PAT tokens.

## Changes

- Removed `persist-credentials: false` from both checkout steps in `.github/workflows/release-plz.yml`
- This allows the workflow to properly use the PAT token for authentication

## Testing

- [ ] Workflow should now authenticate properly with PAT tokens
- [ ] Release-plz actions should work without authentication issues

## Related Issues

Fixes authentication issues with release-plz workflow.