### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [0.1.1](https://github.com/loonghao/turbo-cdn/compare/v0.1.0...v0.1.1) - 2025-06-20
+
+### Added
+
+- add universal URL optimization with comprehensive test coverage
+- implement remaining TODO items and complete API functionality
+- implement cache statistics tracking and metadata persistence
+
+### Other
+
+- improve code quality and remove code smells
 ## [Unreleased]
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2639,7 +2639,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "turbo-cdn"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "turbo-cdn"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["Hal <hal.long@outlook.com>"]
 description = "Revolutionary global download accelerator for open-source software with AI optimization, multi-CDN routing, and P2P acceleration"


### PR DESCRIPTION



## 🤖 New release

* `turbo-cdn`: 0.1.0 -> 0.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/loonghao/turbo-cdn/compare/v0.1.0...v0.1.1) - 2025-06-20

### Added

- add universal URL optimization with comprehensive test coverage
- implement remaining TODO items and complete API functionality
- implement cache statistics tracking and metadata persistence

### Other

- improve code quality and remove code smells
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).