### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.2.0](https://github.com/loonghao/turbo-cdn/compare/v0.1.2...v0.2.0) - 2025-06-21
+
+### Added
+
+- implement automatic geo-detection and performance data persistence
+
+### Fixed
+
+- correct DownloadOptions timeout field type in documentation and examples
+- resolve all test compilation and runtime issues
+
 ## [0.1.2](https://github.com/loonghao/turbo-cdn/compare/v0.1.1...v0.1.2) - 2025-06-21
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2820,7 +2820,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "turbo-cdn"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "turbo-cdn"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 authors = ["Hal <hal.long@outlook.com>"]
 description = "Revolutionary global download accelerator for open-source software with AI optimization, multi-CDN routing, and P2P acceleration"


### PR DESCRIPTION



## 🤖 New release

* `turbo-cdn`: 0.1.2 -> 0.2.0 (⚠ API breaking changes)

### ⚠ `turbo-cdn` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field LoggingConfig.output in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:525
  field LoggingConfig.audit_enabled in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:529
  field LoggingConfig.audit_file in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:533
  field LoggingConfig.rotation in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:537
  field MirrorConfig.description in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:201
  field MirrorConfig.sources in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:204
  field MirrorConfig.url_patterns in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:208
  field MirrorConfig.health_check in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:212
  field MirrorConfig.warning in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:216
  field MirrorConfig.timeout in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:220
  field MirrorConfig.base_url in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:228
  field MirrorConfig.description in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:201
  field MirrorConfig.sources in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:204
  field MirrorConfig.url_patterns in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:208
  field MirrorConfig.health_check in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:212
  field MirrorConfig.warning in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:216
  field MirrorConfig.timeout in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:220
  field MirrorConfig.api_base_url in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:224
  field MirrorConfig.token in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:236
  field MirrorConfig.description in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:201
  field MirrorConfig.sources in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:204
  field MirrorConfig.url_patterns in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:208
  field MirrorConfig.health_check in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:212
  field MirrorConfig.warning in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:216
  field MirrorConfig.timeout in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:220
  field MirrorConfig.api_base_url in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:224
  field MirrorConfig.token in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:236
  field MirrorConfig.description in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:201
  field MirrorConfig.sources in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:204
  field MirrorConfig.url_patterns in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:208
  field MirrorConfig.health_check in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:212
  field MirrorConfig.warning in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:216
  field MirrorConfig.timeout in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:220
  field MirrorConfig.api_base_url in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:224
  field MirrorConfig.token in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:236
  field DataProtectionConfig.retention_days in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:512
  field GeneralConfig.enabled in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:78
  field GeneralConfig.config_check_interval in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:82
  field GeneralConfig.config_cache_ttl in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:86
  field GeneralConfig.debug_mode in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:90
  field GeneralConfig.app_name in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:94
  field GeneralConfig.user_agent_template in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:98
  field CacheConfig.directory in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:434
  field GlobalConfig.meta in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:21
  field GlobalConfig.regions in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:27
  field GlobalConfig.mirrors in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:30
  field GlobalConfig.domains in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:33
  field GlobalConfig.performance in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:36
  field GlobalConfig.security in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:39
  field GlobalConfig.monitoring in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:45
  field GlobalConfig.experimental in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:49
  field GlobalConfig.meta in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:21
  field GlobalConfig.regions in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:27
  field GlobalConfig.mirrors in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:30
  field GlobalConfig.domains in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:33
  field GlobalConfig.performance in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:36
  field GlobalConfig.security in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:39
  field GlobalConfig.monitoring in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:45
  field GlobalConfig.experimental in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:49
  field SecurityConfig.verify_ssl in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:458
  field SecurityConfig.verify_checksums in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:462
  field SecurityConfig.allowed_protocols in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:465
  field SecurityConfig.user_agent in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:468
  field SecurityConfig.custom_headers in /tmp/.tmpP3xApx/turbo-cdn/src/config/models.rs:472

--- failure derive_trait_impl_removed: built-in derived trait no longer implemented ---

Description:
A public type has stopped deriving one or more traits. This can break downstream code that depends on those types implementing those traits.
        ref: https://doc.rust-lang.org/reference/attributes/derive.html#derive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/derive_trait_impl_removed.ron

Failed in:
  type Region no longer derives Copy, in /tmp/.tmpP3xApx/turbo-cdn/src/config/mod.rs:26
  type Region no longer derives Copy, in /tmp/.tmpP3xApx/turbo-cdn/src/config/mod.rs:26

--- failure enum_discriminants_undefined_non_unit_variant: enum's variants no longer have defined discriminants due to non-unit variant ---

Description:
An enum's variants no longer have well-defined discriminant values due to a tuple or struct variant in the enum. This breaks downstream code that accesses discriminants via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_discriminants_undefined_non_unit_variant.ron

Failed in:
  enum Region in /tmp/.tmpP3xApx/turbo-cdn/src/config/mod.rs:26
  enum Region in /tmp/.tmpP3xApx/turbo-cdn/src/config/mod.rs:26

--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_missing.ron

Failed in:
  enum turbo_cdn::config::LogFormat, previously in file /tmp/.tmplQVrPc/turbo-cdn/src/config.rs:307

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_variant_added.ron

Failed in:
  variant Region:Custom in /tmp/.tmpP3xApx/turbo-cdn/src/config/mod.rs:33
  variant Region:Custom in /tmp/.tmpP3xApx/turbo-cdn/src/config/mod.rs:33

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/inherent_method_missing.ron

Failed in:
  GlobalConfig::from_file, previously in file /tmp/.tmplQVrPc/turbo-cdn/src/config.rs:450
  GlobalConfig::to_file, previously in file /tmp/.tmplQVrPc/turbo-cdn/src/config.rs:462
  GlobalConfig::validate, previously in file /tmp/.tmplQVrPc/turbo-cdn/src/config.rs:473
  GlobalConfig::read_timeout, previously in file /tmp/.tmplQVrPc/turbo-cdn/src/config.rs:525
  GlobalConfig::retry_delay, previously in file /tmp/.tmplQVrPc/turbo-cdn/src/config.rs:530
  GlobalConfig::from_file, previously in file /tmp/.tmplQVrPc/turbo-cdn/src/config.rs:450
  GlobalConfig::to_file, previously in file /tmp/.tmplQVrPc/turbo-cdn/src/config.rs:462
  GlobalConfig::validate, previously in file /tmp/.tmplQVrPc/turbo-cdn/src/config.rs:473
  GlobalConfig::read_timeout, previously in file /tmp/.tmplQVrPc/turbo-cdn/src/config.rs:525
  GlobalConfig::retry_delay, previously in file /tmp/.tmplQVrPc/turbo-cdn/src/config.rs:530

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/struct_missing.ron

Failed in:
  struct turbo_cdn::config::ProxyConfig, previously in file /tmp/.tmplQVrPc/turbo-cdn/src/config.rs:209
  struct turbo_cdn::config::MetricsConfig, previously in file /tmp/.tmplQVrPc/turbo-cdn/src/config.rs:279
  struct turbo_cdn::config::CustomSourceConfig, previously in file /tmp/.tmplQVrPc/turbo-cdn/src/config.rs:190
  struct turbo_cdn::config::NetworkConfig, previously in file /tmp/.tmplQVrPc/turbo-cdn/src/config.rs:57
  struct turbo_cdn::config::SourcesConfig, previously in file /tmp/.tmplQVrPc/turbo-cdn/src/config.rs:113

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field file_path of struct LoggingConfig, previously in file /tmp/.tmplQVrPc/turbo-cdn/src/config.rs:268
  field console of struct LoggingConfig, previously in file /tmp/.tmplQVrPc/turbo-cdn/src/config.rs:271
  field check_copyright of struct SecurityConfig, previously in file /tmp/.tmplQVrPc/turbo-cdn/src/config.rs:230
  field network of struct GlobalConfig, previously in file /tmp/.tmplQVrPc/turbo-cdn/src/config.rs:18
  field cache of struct GlobalConfig, previously in file /tmp/.tmplQVrPc/turbo-cdn/src/config.rs:21
  field sources of struct GlobalConfig, previously in file /tmp/.tmplQVrPc/turbo-cdn/src/config.rs:24
  field compliance of struct GlobalConfig, previously in file /tmp/.tmplQVrPc/turbo-cdn/src/config.rs:27
  field metrics of struct GlobalConfig, previously in file /tmp/.tmplQVrPc/turbo-cdn/src/config.rs:33
  field network of struct GlobalConfig, previously in file /tmp/.tmplQVrPc/turbo-cdn/src/config.rs:18
  field cache of struct GlobalConfig, previously in file /tmp/.tmplQVrPc/turbo-cdn/src/config.rs:21
  field sources of struct GlobalConfig, previously in file /tmp/.tmplQVrPc/turbo-cdn/src/config.rs:24
  field compliance of struct GlobalConfig, previously in file /tmp/.tmplQVrPc/turbo-cdn/src/config.rs:27
  field metrics of struct GlobalConfig, previously in file /tmp/.tmplQVrPc/turbo-cdn/src/config.rs:33
  field rate_limit of struct MirrorConfig, previously in file /tmp/.tmplQVrPc/turbo-cdn/src/config.rs:143
  field minimal_data_collection of struct DataProtectionConfig, previously in file /tmp/.tmplQVrPc/turbo-cdn/src/config.rs:249
  field data_retention_days of struct DataProtectionConfig, previously in file /tmp/.tmplQVrPc/turbo-cdn/src/config.rs:255
  field debug of struct GeneralConfig, previously in file /tmp/.tmplQVrPc/turbo-cdn/src/config.rs:52
  field cache_dir of struct CacheConfig, previously in file /tmp/.tmplQVrPc/turbo-cdn/src/config.rs:96
  field compression of struct CacheConfig, previously in file /tmp/.tmplQVrPc/turbo-cdn/src/config.rs:105
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/loonghao/turbo-cdn/compare/v0.1.2...v0.2.0) - 2025-06-21

### Added

- implement automatic geo-detection and performance data persistence

### Fixed

- correct DownloadOptions timeout field type in documentation and examples
- resolve all test compilation and runtime issues
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).