### PR TITLE
chore: release v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - improve code quality and remove code smells
 ## [Unreleased]
 
+## [0.4.1](https://github.com/loonghao/turbo-cdn/compare/v0.4.0...v0.4.1) - 2025-06-25
+
+### Added
+
+- simplify release workflow using upload-rust-binary-action
+- integrate release-plz with GitHub release automation
+
+### Fixed
+
+- restore git_release_body template for rich release notes
+
 ## [0.4.0](https://github.com/loonghao/turbo-cdn/compare/v0.3.0...v0.4.0) - 2025-06-25
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2882,7 +2882,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "turbo-cdn"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "ahash",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "turbo-cdn"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 authors = ["Hal <hal.long@outlook.com>"]
 description = "Intelligent download accelerator with automatic CDN optimization and concurrent chunked downloads"


### PR DESCRIPTION



## 🤖 New release

* `turbo-cdn`: 0.4.0 -> 0.4.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.1](https://github.com/loonghao/turbo-cdn/compare/v0.2.0...v0.2.1) - 2025-06-23

### Fixed

- *(deps)* update rust crate directories to v6
- resolve cross-platform path issues and optimize HTTP client

### Other

- upgrade to directories crate for better cross-platform path management
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).