### PR TITLE
chore: release v0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - improve code quality and remove code smells
 ## [Unreleased]
 
+## [0.4.3](https://github.com/loonghao/turbo-cdn/compare/v0.4.2...v0.4.3) - 2025-07-03
+
+### Added
+
+- optimize build profiles and clippy configuration
+
+### Other
+
+- update README to reflect current architecture
+
 ## [0.4.2](https://github.com/loonghao/turbo-cdn/compare/v0.4.1...v0.4.2) - 2025-07-03
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2895,7 +2895,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "turbo-cdn"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "ahash",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "turbo-cdn"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 authors = ["Hal <hal.long@outlook.com>"]
 description = "Intelligent download accelerator with automatic CDN optimization and concurrent chunked downloads"


### PR DESCRIPTION



## 🤖 New release

* `turbo-cdn`: 0.4.2 -> 0.4.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.1](https://github.com/loonghao/turbo-cdn/compare/v0.2.0...v0.2.1) - 2025-06-23

### Fixed

- *(deps)* update rust crate directories to v6
- resolve cross-platform path issues and optimize HTTP client

### Other

- upgrade to directories crate for better cross-platform path management
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).