### PR TITLE
fix: convert workspace config to single package config for release-plz

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,4 +1,4 @@
-# Release-plz configuration for turbo-cdn
+# Release-plz configuration for turbo-cdn (single package project)
 #
 # Strategy: release-plz handles crates.io publishing and creates GitHub releases,
 # while .github/workflows/release.yml builds cross-platform binaries using upload-rust-binary-action.
@@ -12,15 +12,23 @@
 # This approach leverages release-plz's strengths (version management, changelog, crates.io)
 # while using the specialized upload-rust-binary-action for cross-platform builds.
 
-[workspace]
+# Single package configuration (no workspace needed)
 # Enable automatic changelog generation
 changelog_update = true
-# Disable GitHub releases at workspace level (handled by package level)
-git_release_enable = false
+# Enable GitHub releases for binary distribution
+git_release_enable = true
 # Enable automatic tag creation (triggers release.yml)
 git_tag_enable = true
+# Standard tag format (triggers release workflows) - with 'v' prefix to trigger release.yml
+git_tag_name = "v{{version}}"
 # Enable processing for releases
 release = true
+# Allow major version bumps for breaking changes
+allow_dirty = false
+# Ensure proper semantic versioning
+semver_check = true
+# Create published releases (upload-rust-binary-action will add binaries)
+git_release_draft = false
 
 # Changelog configuration
 [changelog]
@@ -34,23 +42,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 """
 
-# Package-specific configuration for turbo-cdn
-[[package]]
-name = "turbo-cdn"
-# Enable changelog updates
-changelog_update = true
-# Enable GitHub releases (release-plz creates draft, release.yml adds binaries and publishes)
-git_release_enable = true
-# Enable processing for releases
-release = true
-# Standard tag format (triggers release workflows) - with 'v' prefix to trigger release.yml
-git_tag_name = "v{{version}}"
-# Allow major version bumps for breaking changes
-allow_dirty = false
-# Ensure proper semantic versioning
-semver_check = true
-# Create published releases (upload-rust-binary-action will add binaries)
-git_release_draft = false
 # Custom release body template
 git_release_body = """
 ## 🚀 What's Changed


### PR DESCRIPTION
## 🔧 Problem Solved

Fixed release-plz configuration mismatch where workspace format was incorrectly used for a single package project.

## 📋 Key Changes

### ⚙️ Configuration Structure Fix
- **Removed `[workspace]` section** - turbo-cdn is a single package project, not a workspace
- **Moved all settings to root level** - proper single package configuration format
- **Eliminated `[[package]]` section** - not needed for single package projects

### 🎨 Maintained Functionality
- ✅ **GitHub releases** - `git_release_enable = true`
- ✅ **Crates.io publishing** - `release = true`
- ✅ **Tag creation** - `git_tag_enable = true` with `v{{version}}` format
- ✅ **Changelog generation** - `changelog_update = true`
- ✅ **Custom release body** - Rich installation instructions preserved

### 🔄 Improved Configuration
- **Cleaner structure** - Single package format is more appropriate
- **Better maintainability** - Simpler configuration without workspace complexity
- **Correct semantics** - Matches actual project structure

## 🔍 Root Cause

The original configuration used workspace format (`[workspace]` + `[[package]]`) for a single package project. This can cause:
- Confusion in release-plz processing
- Potential issues with version management
- Unnecessary complexity

## ✅ Benefits

- **🎨 Cleaner configuration** - Matches single package project structure
- **🔧 Better semantics** - Correct format for project type
- **🚀 Same functionality** - All features preserved
- **📝 Easier maintenance** - Simpler configuration to understand

## 🧪 Testing

- ✅ Configuration syntax validated
- ✅ All required fields present
- ✅ Tag format preserved (`v{{version}}`)
- ✅ Release body template maintained

---

**Ready for merge** - This fixes the configuration mismatch and establishes the correct single package format for release-plz.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author