### PR TITLE
fix(deps): disable default-features for self_update to avoid default-tls conflict

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,7 @@ brotli = "8.0"
 ping = "0.7"
 
 # Self-update functionality
-self_update = { version = "0.42", features = ["archive-tar", "archive-zip", "compression-flate2", "compression-zip-deflate", "rustls"] }
+self_update = { version = "0.42", default-features = false, features = ["archive-tar", "archive-zip", "compression-flate2", "compression-zip-deflate", "rustls"] }
 
 [dev-dependencies]
 # Testing


### PR DESCRIPTION
## Problem

The `self_update` crate was using reqwest with default features enabled, which includes `default-tls`. This conflicts with our explicit `rustls-tls` configuration in the project.

## Solution

Set `default-features = false` for `self_update` dependency to ensure only the explicitly specified features are used:

```toml
self_update = { version = "0.42", default-features = false, features = ["archive-tar", "archive-zip", "compression-flate2", "compression-zip-deflate", "rustls"] }
```

## Testing

- [x] `cargo clippy --all-targets --all-features` passes
- [x] `cargo fmt --all --check` passes