### PR TITLE
chore: release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - improve code quality and remove code smells
 ## [Unreleased]
 
+## [0.8.0](https://github.com/loonghao/turbo-cdn/compare/v0.7.1...v0.8.0) - 2026-01-10
+
+### Added
+
+- rustls ring backend and self-update opt-in
+
+### Fixed
+
+- remove extra blank lines after rustls init calls for fmt compliance
+- make init_rustls_provider public and add to ConcurrentDownloader
+- initialize rustls ring provider before creating reqwest clients
+
+### Other
+
+- *(deps)* update rust crate tokio-util to v0.7.18
+- *(deps)* update rust crate url to v2.5.8
+- *(deps)* update rust crate rustls to v0.23.36
+- *(deps)* update rust crate tokio-test to v0.4.5
+- *(deps)* update rust crate serde_json to v1.0.149
+
 ## [0.7.1](https://github.com/loonghao/turbo-cdn/compare/v0.7.0...v0.7.1) - 2026-01-03
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3164,7 +3164,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "turbo-cdn"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "ahash",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "turbo-cdn"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2021"
 authors = ["Hal <hal.long@outlook.com>"]
 description = "Intelligent download accelerator with automatic CDN optimization and concurrent chunked downloads"


### PR DESCRIPTION



## 🤖 New release

* `turbo-cdn`: 0.7.1 -> 0.8.0 (⚠ API breaking changes)

### ⚠ `turbo-cdn` breaking changes

```text
--- failure feature_not_enabled_by_default: package feature is not enabled by default ---

Description:
A feature is no longer enabled by default for this package. This will break downstream crates which rely on the package's default features and require the functionality of this feature.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#cargo-feature-remove-another
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/feature_not_enabled_by_default.ron

Failed in:
  feature self-update in the package's Cargo.toml
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.1](https://github.com/loonghao/turbo-cdn/compare/v0.2.0...v0.2.1) - 2025-06-23

### Fixed

- *(deps)* update rust crate directories to v6
- resolve cross-platform path issues and optimize HTTP client

### Other

- upgrade to directories crate for better cross-platform path management
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).