### PR TITLE
fix(ci): upgrade macOS runner from macos-13 to macos-15

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,9 +34,9 @@ jobs:
             os: ubuntu-22.04
           # macOS targets
           - target: x86_64-apple-darwin
-            os: macos-13
+            os: macos-15
           - target: aarch64-apple-darwin
-            os: macos-13
+            os: macos-15
           # Windows targets
           - target: x86_64-pc-windows-msvc
             os: windows-2022


### PR DESCRIPTION
## Summary

Upgrade macOS runner from `macos-13` to `macos-15` in the release workflow.

## Problem

The macos-13 based runner images are now retired, causing release workflow failures:
- Upload release assets (x86_64-apple-darwin, macos-13) - FAILED
- Upload release assets (aarch64-apple-darwin, macos-13) - FAILED

See: https://github.com/actions/runner-images/issues/13046

## Solution

Update `.github/workflows/release.yml` to use `macos-15` instead of `macos-13` for macOS targets.

## Changes

- `x86_64-apple-darwin`: macos-13 → macos-15
- `aarch64-apple-darwin`: macos-13 → macos-15