### PR TITLE
fix: make rustls and rustls-webpki optional dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,10 @@ exclude = ["/.github/", "/tests/fixtures/", "*.md"]
 tokio = { version = "1.0", features = ["full", "fs"] }
 
 # HTTP client - optimized for performance and cross-platform compatibility
-# Use rustls with native roots by default (ring backend to avoid aws-lc toolchain requirements)
+# TLS backend is controlled by features: rustls (default) or native-tls
 reqwest = { version = "0.13.1", features = [
     "json",
     "stream",
-    "rustls-no-provider", # use custom rustls provider (ring) to avoid aws-lc-sys toolchain
     "gzip",
     "brotli",
     "deflate",
@@ -36,8 +35,9 @@ reqwest = { version = "0.13.1", features = [
 ], default-features = false }
 
 # TLS stack: prefer ring backend to avoid cmake/NASM on Windows
-rustls = { version = "0.23.35", default-features = false, features = ["std", "logging", "tls12", "ring"] }
-rustls-webpki = { version = "0.103.8", default-features = false, features = ["std", "ring"] }
+# Made optional so downstream crates using native-tls don't pull in rustls
+rustls = { version = "0.23.35", default-features = false, features = ["std", "logging", "tls12", "ring"], optional = true }
+rustls-webpki = { version = "0.103.8", default-features = false, features = ["std", "ring"], optional = true }
 
 
 
@@ -123,7 +123,9 @@ serial_test = "3.0"
 [features]
 # Default features are library-friendly: self-update is opt-in; rustls uses ring backend without aws-lc-sys
 default = ["rustls", "fast-hash", "high-performance"]
-rustls = ["reqwest/rustls-no-provider"]
+# rustls TLS backend (includes rustls and rustls-webpki dependencies)
+rustls = ["reqwest/rustls-no-provider", "dep:rustls", "dep:rustls-webpki"]
+# native-tls TLS backend (uses system TLS, no rustls dependencies)
 native-tls = ["reqwest/native-tls"]
 fast-hash = ["ahash"]
 high-performance = []

--- a/README.md
+++ b/README.md
@@ -91,18 +91,20 @@ turbo-cdn = { version = "0.8", features = ["rustls", "fast-hash", "high-performa
 # CLI build with self-update enabled
 turbo-cdn = { version = "0.8", default-features = false, features = ["rustls", "fast-hash", "high-performance", "self-update"] }
 
-# Windows-friendly native TLS (SChannel) if you prefer not to use rustls
+# Use native TLS (SChannel on Windows, Secure Transport on macOS) - no rustls dependencies
 turbo-cdn = { version = "0.8", default-features = false, features = ["native-tls", "fast-hash", "high-performance"] }
 
 ```
 
 | Feature | Default | Description |
 |---------|---------|-------------|
-| `rustls` | Yes | TLS via rustls (ring backend, no cmake/NASM toolchain required) |
-| `native-tls` | No | Use native TLS (SChannel/Secure Transport) instead of rustls |
+| `rustls` | Yes | TLS via rustls with ring backend (no cmake/NASM toolchain required). Includes `rustls` and `rustls-webpki` dependencies. |
+| `native-tls` | No | Use native TLS (SChannel on Windows, Secure Transport on macOS). Does NOT pull in rustls dependencies. |
 | `fast-hash` | Yes | Use ahash for faster hashing |
 | `high-performance` | Yes | Enable high-performance optimizations |
 | `self-update` | No | CLI self-update functionality (opt-in for binaries) |
+
+> **Note for downstream crates:** When using `native-tls` feature, `rustls` and `rustls-webpki` are NOT included as dependencies. This allows downstream crates to use their own TLS configuration without conflicts.
 
 ## 📊 Supported Package Managers
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -91,18 +91,20 @@ turbo-cdn = { version = "0.8", features = ["rustls", "fast-hash", "high-performa
 # CLI 版本启用自更新
 turbo-cdn = { version = "0.8", default-features = false, features = ["rustls", "fast-hash", "high-performance", "self-update"] }
 
-# 如需使用原生 TLS（Windows SChannel）
+# 使用原生 TLS（Windows SChannel，macOS Secure Transport）- 不引入 rustls 依赖
 turbo-cdn = { version = "0.8", default-features = false, features = ["native-tls", "fast-hash", "high-performance"] }
 
 ```
 
 | Feature | 默认 | 描述 |
 |---------|------|------|
-| `rustls` | 是 | 通过 rustls（ring 后端，无需 cmake/NASM）进行 TLS |
-| `native-tls` | 否 | 使用原生 TLS（SChannel/Secure Transport）替代 rustls |
+| `rustls` | 是 | 通过 rustls（ring 后端，无需 cmake/NASM）进行 TLS。包含 `rustls` 和 `rustls-webpki` 依赖。 |
+| `native-tls` | 否 | 使用原生 TLS（Windows SChannel，macOS Secure Transport）。不会引入 rustls 相关依赖。 |
 | `fast-hash` | 是 | 使用 ahash 加速哈希 |
 | `high-performance` | 是 | 启用高性能优化 |
 | `self-update` | 否 | CLI 自更新功能（按需开启） |
+
+> **下游 crate 注意：** 使用 `native-tls` feature 时，`rustls` 和 `rustls-webpki` 不会作为依赖引入。这允许下游 crate 使用自己的 TLS 配置而不会产生冲突。
 
 ## 📊 支持的包管理器
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,15 +35,24 @@
 //! ```
 
 // Initialize rustls crypto provider once (required when using rustls-no-provider feature)
+#[cfg(feature = "rustls")]
 use std::sync::Once;
+#[cfg(feature = "rustls")]
 static INIT_RUSTLS: Once = Once::new();
 
 /// Initialize rustls crypto provider (ring backend)
 /// This must be called before creating any reqwest Client when using rustls-no-provider
+#[cfg(feature = "rustls")]
 pub fn init_rustls_provider() {
     INIT_RUSTLS.call_once(|| {
         let _ = rustls::crypto::ring::default_provider().install_default();
     });
+}
+
+/// No-op when rustls feature is disabled
+#[cfg(not(feature = "rustls"))]
+pub fn init_rustls_provider() {
+    // No-op: rustls is not enabled, using native-tls or other TLS backend
 }
 
 pub mod adaptive_concurrency;

--- a/tests/feature_tests.rs
+++ b/tests/feature_tests.rs
@@ -46,3 +46,64 @@ fn test_feature_flags() {
         );
     }
 }
+
+/// Test that rustls feature is properly configured
+#[test]
+fn test_rustls_feature_flag() {
+    #[cfg(feature = "rustls")]
+    {
+        assert!(
+            cfg!(feature = "rustls"),
+            "rustls feature should be enabled when opted in"
+        );
+    }
+
+    #[cfg(not(feature = "rustls"))]
+    {
+        assert!(
+            !cfg!(feature = "rustls"),
+            "rustls feature should be disabled when not requested"
+        );
+    }
+}
+
+/// Test that native-tls feature is properly configured
+#[test]
+fn test_native_tls_feature_flag() {
+    #[cfg(feature = "native-tls")]
+    {
+        assert!(
+            cfg!(feature = "native-tls"),
+            "native-tls feature should be enabled when opted in"
+        );
+    }
+
+    #[cfg(not(feature = "native-tls"))]
+    {
+        assert!(
+            !cfg!(feature = "native-tls"),
+            "native-tls feature should be disabled when not requested"
+        );
+    }
+}
+
+/// Test that init_rustls_provider works correctly based on feature
+#[test]
+fn test_init_rustls_provider() {
+    // This should compile and run regardless of which TLS backend is enabled
+    // When rustls is enabled, it initializes the provider
+    // When rustls is disabled, it's a no-op
+    turbo_cdn::init_rustls_provider();
+}
+
+/// Test that TLS backend is mutually exclusive in practice
+/// Note: Both features can technically be enabled, but only one should be used
+#[test]
+fn test_tls_backend_configuration() {
+    // At least one TLS backend should be available
+    let has_tls = cfg!(feature = "rustls") || cfg!(feature = "native-tls");
+    assert!(
+        has_tls || cfg!(test), // In test mode, we might have neither explicitly set
+        "At least one TLS backend should be configured for production use"
+    );
+}


### PR DESCRIPTION
## Summary

Make `rustls` and `rustls-webpki` optional dependencies that are only included when the `rustls` feature is enabled.

## Problem

Previously, `rustls` and `rustls-webpki` were direct dependencies in `Cargo.toml`, which meant downstream crates using `native-tls` feature would still pull in rustls dependencies. This caused conflicts for crates that wanted to use their own TLS configuration.

## Solution

1. **Made `rustls` and `rustls-webpki` optional dependencies** - They are now only included when the `rustls` feature is enabled
2. **Added conditional compilation for `init_rustls_provider()`** - The function is a no-op when rustls is disabled
3. **Moved `rustls-no-provider` from reqwest's direct features to the `rustls` feature** - This ensures reqwest doesn't pull in rustls when using native-tls

## Changes

- `Cargo.toml`: Made rustls/rustls-webpki optional, updated feature definitions
- `src/lib.rs`: Added `#[cfg(feature = "rustls")]` conditional compilation
- `tests/feature_tests.rs`: Added tests for TLS feature flags
- `README.md` / `README_zh.md`: Updated documentation to clarify TLS backend behavior

## Verification

```bash
# Verify rustls is NOT included with native-tls
cargo tree --no-default-features --features "native-tls,fast-hash,high-performance" -i rustls
# Output: warning: nothing to print.

# Verify both configurations compile and pass tests
cargo test --no-default-features --features "native-tls,fast-hash,high-performance"
cargo test  # default features (rustls)
```

## Breaking Changes

None. The default behavior remains the same (rustls enabled by default).