### PR TITLE
fix(ci): prevent duplicate release-plz PRs on release merge

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -14,7 +14,8 @@ jobs:
   release-plz-release:
     name: Release-plz release
     runs-on: ubuntu-latest
-    if: ${{ github.repository_owner == 'loonghao' }}
+    # Skip if triggered by release-plz's own PR merge (prevents duplicate releases)
+    if: ${{ github.repository_owner == 'loonghao' && !startsWith(github.event.head_commit.message, 'chore: release') }}
     permissions:
       contents: write
     steps:
@@ -41,7 +42,8 @@ jobs:
   release-plz-pr:
     name: Release-plz PR
     runs-on: ubuntu-latest
-    if: ${{ github.repository_owner == 'loonghao' }}
+    # Skip if triggered by release-plz's own PR merge (prevents duplicate PRs)
+    if: ${{ github.repository_owner == 'loonghao' && !startsWith(github.event.head_commit.message, 'chore: release') }}
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Problem

When a release-plz PR (e.g., `chore: release v0.8.1`) is merged to main, it triggers the release-plz workflow again, which creates a duplicate release PR.

As shown in the screenshot, both #107 and #109 are release PRs for the same version.

## Solution

Add a condition to skip the release-plz workflow when the commit message starts with `chore: release`. This prevents the workflow from running when its own PR is merged.

```yaml
if: ${{ github.repository_owner == 'loonghao' && !startsWith(github.event.head_commit.message, 'chore: release') }}
```

## Changes

- `.github/workflows/release-plz.yml`: Added skip condition for both `release-plz-release` and `release-plz-pr` jobs