### PR TITLE
chore: release v0.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - improve code quality and remove code smells
 ## [Unreleased]
 
+## [0.8.4](https://github.com/loonghao/turbo-cdn/compare/v0.8.3...v0.8.4) - 2026-04-11
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.8.3](https://github.com/loonghao/turbo-cdn/compare/v0.8.2...v0.8.3) - 2026-03-04
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3149,7 +3149,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "turbo-cdn"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "ahash",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "turbo-cdn"
-version = "0.8.3"
+version = "0.8.4"
 edition = "2021"
 authors = ["Hal <hal.long@outlook.com>"]
 description = "Intelligent download accelerator with automatic CDN optimization and concurrent chunked downloads"


### PR DESCRIPTION



## 🤖 New release

* `turbo-cdn`: 0.8.3 -> 0.8.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>


## [0.8.4](https://github.com/loonghao/turbo-cdn/compare/v0.8.3...v0.8.4) - 2026-04-11

### Other

- update Cargo.lock dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).